### PR TITLE
Depend on cmsis-core

### DIFF
--- a/module.json
+++ b/module.json
@@ -10,7 +10,9 @@
   },
   "homepage": "https://github.com/ARMmbed/mbed-net-socket-abstract",
   "license": "Apache-2",
-  "dependencies": {},
+  "dependencies": {
+    "cmsis-core": "*"
+  },
   "scripts": {
     "testReporter": [
       "mbedgt",


### PR DESCRIPTION
Fix for https://github.com/ARMmbed/sal/issues/23

```
FAILED: C:\winapps\Eclipse_Toolchain\GNU_Tools_ARM_Embedded\4.9_2015q1\bin\arm-none-eabi-gcc.exe   -std=c99 -fno-exceptions -fno-unwind-tables -ffunction-sections -fdata-sections -Wall -Wextra -mcpu=cortex-m0 -mthumb -D__thumb2__ -Os -g -gdwarf-3 -DNDEBUG -Igenerated/include -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/tri-stc -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/tri-stc-object-identify -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/tri-i2c-sockets -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/lwm2mclient -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/cmsis-core -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/mbed-hal -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/mbed-client -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/cmsis-core-st -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/cmsis-core-stm32f0 -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/mbed-hal-st-stm32f0 -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/cmsis-core-stm32f091rc -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/uvisor-lib -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/mbed-hal-st-stm32cubef0 -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/mbed-hal-st-stm32f091rc -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/mbed-drivers -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/ualloc -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/minar -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/core-util -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/compiler-polyfill -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/mbed-hal-st -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/dlmalloc -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/minar-platform -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/minar-platform-mbed -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/mbed-client-c -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/mbed-client-mbed-os -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/nanostack-libservice -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/sockets -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/sal -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/sal/source    -DTOOLCHAIN_GCC -DTOOLCHAIN_GCC_ARM -DMBED_OPERATORS -DTARGET_NUCLEO_F091RC -DTARGET_STM32F091RC -DTARGET_STM32F0 -DTOOLCHAIN_GCC -DTOOLCHAIN_GCC_ARM -include "C:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/build/st-nucleo-f091rc-gcc/yotta_config.h" -MMD -MT ym/sal/source/CMakeFiles/sal.dir/C_/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/sal/source/socket_abstract.c.o -MF ym/sal/source/CMakeFiles/sal.dir/C_/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/sal/source/socket_abstract.c.o.d -o ym/sal/source/CMakeFiles/sal.dir/C_/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/sal/source/socket_abstract.c.o -c C:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/sal/source/socket_abstract.c
In file included from C:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/sal/source/socket_abstract.c:17:0:
C:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/sal/mbed-net-socket-abstract/socket_api.h:95:19: fatal error: cmsis.h: No such file or directory
 #include "cmsis.h"
                   ^
compilation terminated.
FAILED: C:\winapps\Eclipse_Toolchain\GNU_Tools_ARM_Embedded\4.9_2015q1\bin\arm-none-eabi-g++.exe   -fno-exceptions -fno-unwind-tables -ffunction-sections -fdata-sections -Wall -Wextra -fno-rtti -fno-threadsafe-statics -mcpu=cortex-m0 -mthumb -D__thumb2__ -Os -g -gdwarf-3 -DNDEBUG -Igenerated/include -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/tri-stc -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/tri-stc-object-identify -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/tri-i2c-sockets -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/lwm2mclient -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/cmsis-core -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/mbed-hal -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/mbed-client -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/cmsis-core-st -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/cmsis-core-stm32f0 -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/mbed-hal-st-stm32f0 -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/cmsis-core-stm32f091rc -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/uvisor-lib -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/mbed-hal-st-stm32cubef0 -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/mbed-hal-st-stm32f091rc -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/mbed-drivers -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/ualloc -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/minar -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/core-util -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/compiler-polyfill -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/mbed-hal-st -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/dlmalloc -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/minar-platform -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/minar-platform-mbed -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/mbed-client-c -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/mbed-client-mbed-os -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/nanostack-libservice -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/sockets -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/sal -IC:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/sal/source    -DTOOLCHAIN_GCC -DTOOLCHAIN_GCC_ARM -DMBED_OPERATORS -DTARGET_NUCLEO_F091RC -DTARGET_STM32F091RC -DTARGET_STM32F0 -DTOOLCHAIN_GCC -DTOOLCHAIN_GCC_ARM -include "C:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/build/st-nucleo-f091rc-gcc/yotta_config.h" -MMD -MT ym/sal/source/CMakeFiles/sal.dir/C_/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/sal/source/test/socket_abstract_test.cpp.o -MF ym/sal/source/CMakeFiles/sal.dir/C_/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/sal/source/test/socket_abstract_test.cpp.o.d -o ym/sal/source/CMakeFiles/sal.dir/C_/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/sal/source/test/socket_abstract_test.cpp.o -c C:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/sal/source/test/socket_abstract_test.cpp
In file included from C:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/sal/source/test/socket_abstract_test.cpp:19:0:
C:/Users/Markus.Becker/GitRepos/mbed/test5/tri-stc-driver-acdc/yotta_modules/sal/mbed-net-socket-abstract/socket_api.h:95:19: fatal error: cmsis.h: No such file or directory
 #include "cmsis.h"
                   ^
compilation terminated.
ninja: build stopped: subcommand failed.
error: command ['ninja'] failed
```
